### PR TITLE
Handle special characters in og:image titles

### DIFF
--- a/_includes/og-image.njk
+++ b/_includes/og-image.njk
@@ -36,7 +36,7 @@
 
 <div class="root">
     <span class="sig">CSS Tip</span>
-    <h1 class="title">{{ title }}</h1>
+    <h1 class="title">{{ title | safe }}</h1>
     <div class="me"><img src="https://css-tip.com/img/avatar.png" width="150"> <span>Temani Afif</span></div>
     <img src="https://css-tip.com/img/fav.png" class="fav" width="220">
 </div>


### PR DESCRIPTION
Hello!

I have made an enhancement to fix the issue of special characters, such as `&`, being incorrectly escaped (e.g., becoming `&amp;`) in the titles of dynamically generated Open Graph images.

This update ensures that titles are rendered correctly without HTML escaping issues, improving the accuracy and presentation of Open Graph metadata.

Before :
![img 32](https://github.com/user-attachments/assets/588c0edc-94ac-4b88-9d8a-8e421ed8613b)

After :
![img 33](https://github.com/user-attachments/assets/1a942df3-0385-46c6-8bf5-28ece9eaa00f)

Let me know if any adjustments are required,  if for any reason this contribution does not align with the project's current goals or standards, I completely understand it.

Thanks for all your css tips!

Matthieu